### PR TITLE
Added option to allow for mimetype lookup via magic numbers

### DIFF
--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -27,6 +27,11 @@ import 'util.dart';
 ///
 /// If no [defaultDocument] is found and [listDirectories] is true, then the
 /// handler produces a listing of the directory.
+///
+/// If [useHeaderBytesForContentType] is set to false, then the content type will
+/// be determined by the file's extension, as is the mime library's default behavior.
+/// Setting it to true will cause up tot he first 25 bytes of the file to be read
+/// and used to determine the content type.
 Handler createStaticHandler(String fileSystemPath,
     {bool serveFilesOutsidePath: false, String defaultDocument,
     bool listDirectories: false, bool useHeaderBytesForContentType: false}) {

--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -29,7 +29,7 @@ import 'util.dart';
 /// handler produces a listing of the directory.
 Handler createStaticHandler(String fileSystemPath,
     {bool serveFilesOutsidePath: false, String defaultDocument,
-    bool listDirectories: false, bool useMagicBytesForContentType: false}) {
+    bool listDirectories: false, bool useHeaderBytesForContentType: false}) {
   var rootDir = new Directory(fileSystemPath);
   if (!rootDir.existsSync()) {
     throw new ArgumentError('A directory corresponding to fileSystemPath '
@@ -102,8 +102,12 @@ Handler createStaticHandler(String fileSystemPath,
 
 
     var contentType;
-    if(useMagicBytesForContentType) {
-      List<int> magicBytes = await file.openRead(0,2).single;
+    if(useHeaderBytesForContentType) {
+      int length = 25; // The longest file header identifier
+      int file_length =file.lengthSync();
+      if(file_length<length)
+        length = file_length;
+      List<int> magicBytes = await file.openRead(0,length).single;
       contentType = mime.lookupMimeType(file.path, headerBytes: magicBytes);
     } else {
       contentType = mime.lookupMimeType(file.path);

--- a/test/basic_file_test.dart
+++ b/test/basic_file_test.dart
@@ -25,7 +25,7 @@ void main() {
     d.file('index.html', '<html></html>').create();
     d.file('root.txt', 'root txt').create();
     d.file('random.unknown', 'no clue').create();
-    d.binaryFile('magic_bytes_test_image', BASE64.decode(r"iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AYRETkSXaxBzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAbUlEQVQI1wXBvwpBYRwA0HO/kjBKJmXRLWXxJ4PsnsMTeAEPILvNZrybF7B4A6XvQW6k+DkHwqgM1TnMpoEoDMtwOJE7pB/VXmF3CdseucmjxaAruR41Pl9p/Gbyoq5B9FeL2OR7zJ+3aC/X8QdQCyIArPsHkQAAAABJRU5ErkJggg==")).create();
+    d.binaryFile('header_bytes_test_image', BASE64.decode(r"iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AYRETkSXaxBzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAbUlEQVQI1wXBvwpBYRwA0HO/kjBKJmXRLWXxJ4PsnsMTeAEPILvNZrybF7B4A6XvQW6k+DkHwqgM1TnMpoEoDMtwOJE7pB/VXmF3CdseucmjxaAruR41Pl9p/Gbyoq5B9FeL2OR7zJ+3aC/X8QdQCyIArPsHkQAAAABJRU5ErkJggg==")).create();
     d
         .dir('files', [
       d.file('test.txt', 'test txt content'),
@@ -202,9 +202,9 @@ void main() {
 
     test('magic_bytes_test_image should be image/png', () {
       schedule(() {
-        var handler = createStaticHandler(d.defaultRoot, useMagicBytesForContentType: true);
+        var handler = createStaticHandler(d.defaultRoot, useHeaderBytesForContentType: true);
 
-        return makeRequest(handler, '/magic_bytes_test_image').then((response) {
+        return makeRequest(handler, '/header_bytes_test_image').then((response) {
           expect(response.mimeType, "image/png");
         });
       });

--- a/test/basic_file_test.dart
+++ b/test/basic_file_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:convert';
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as p;
 import 'package:scheduled_test/descriptor.dart' as d;
@@ -24,6 +25,7 @@ void main() {
     d.file('index.html', '<html></html>').create();
     d.file('root.txt', 'root txt').create();
     d.file('random.unknown', 'no clue').create();
+    d.binaryFile('magic_bytes_test_image', BASE64.decode(r"iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AYRETkSXaxBzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAbUlEQVQI1wXBvwpBYRwA0HO/kjBKJmXRLWXxJ4PsnsMTeAEPILvNZrybF7B4A6XvQW6k+DkHwqgM1TnMpoEoDMtwOJE7pB/VXmF3CdseucmjxaAruR41Pl9p/Gbyoq5B9FeL2OR7zJ+3aC/X8QdQCyIArPsHkQAAAABJRU5ErkJggg==")).create();
     d
         .dir('files', [
       d.file('test.txt', 'test txt content'),
@@ -194,6 +196,16 @@ void main() {
 
         return makeRequest(handler, '/random.unknown').then((response) {
           expect(response.mimeType, isNull);
+        });
+      });
+    });
+
+    test('magic_bytes_test_image should be image/png', () {
+      schedule(() {
+        var handler = createStaticHandler(d.defaultRoot, useMagicBytesForContentType: true);
+
+        return makeRequest(handler, '/magic_bytes_test_image').then((response) {
+          expect(response.mimeType, "image/png");
         });
       });
     });


### PR DESCRIPTION
Had to re-commit due to my commit's e-mail address:

I'm setting up a server that hosts static images that are named after their hashes without extensions. The current version of the mime library only uses extensions by default to determine the MIME of the file, which means my files get sent as "text/html" instead of the proper image type. In order to make this work, it needed to be changed to send the first two bytes from the file as well. Since this is obviously a performance hit, it's enabled via a named argument on createStaticHandler. Since this involves opening a file, the returned handler had to be changed to async, which shelf of course doesn't care about.