### PR TITLE
Added option to specify a custom MimeTypeResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5
+
+* Add support for using a custom `MimeTypeResolver` for the handler to use when determining 
+  content-type via an optional `contentTypeResolver` argument on `createStaticHandler`.
+
 ## 0.2.4
 
 * Add support for "sniffing" the content of the file for the content-type via an optional

--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -32,6 +32,9 @@ import 'util.dart';
 ///
 /// If [useHeaderBytesForContentType] is `true`, the contents of the
 /// file will be used along with the file path to determine the content type.
+///
+/// Specify a custom [contentTypeResolver] to customize automatic content type
+/// detection.
 Handler createStaticHandler(String fileSystemPath,
     {bool serveFilesOutsidePath: false,
     String defaultDocument,

--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -55,8 +55,7 @@ Handler createStaticHandler(String fileSystemPath,
     }
   }
 
-  if(contentTypeResolver==null)
-    contentTypeResolver = new mime.MimeTypeResolver();
+  contentTypeResolver ??= new mime.MimeTypeResolver();
 
   return (Request request) async {
     var segs = [fileSystemPath]..addAll(request.url.pathSegments);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 0.2.4
+version: 0.2.5
 author: Dart Team <misc@dartlang.org>
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static


### PR DESCRIPTION
The default MimeTypeResolver has limited support for file extensions and header bytes. This change allows you to specify a custom MimeTypeResolver, allowing the developer to add additional extensions and header byte types.