### PR TITLE
Remove deprecated `dart:io` constant uses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7+2
+
+* Remove deprecated `dart:io` constants.
+
 ## 0.2.7+1
 
 * Updated SDK version to 2.0.0-dev.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.2.7+2
-
-* Remove deprecated `dart:io` constants.
-
 ## 0.2.7+1
 
 * Updated SDK version to 2.0.0-dev.17.0

--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -70,9 +70,9 @@ Handler createStaticHandler(String fileSystemPath,
 
     File file;
 
-    if (entityType == FileSystemEntityType.FILE) {
+    if (entityType == FileSystemEntityType.file) {
       file = new File(fsPath);
-    } else if (entityType == FileSystemEntityType.DIRECTORY) {
+    } else if (entityType == FileSystemEntityType.directory) {
       file = _tryDefaultFile(fsPath, defaultDocument);
       if (file == null && listDirectories) {
         var uri = request.requestedUri;
@@ -97,7 +97,7 @@ Handler createStaticHandler(String fileSystemPath,
     // when serving the default document for a directory, if the requested
     // path doesn't end with '/', redirect to the path with a trailing '/'
     var uri = request.requestedUri;
-    if (entityType == FileSystemEntityType.DIRECTORY &&
+    if (entityType == FileSystemEntityType.directory &&
         !uri.path.endsWith('/')) {
       return _redirectToAddTrailingSlash(uri);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: shelf_static
-version: 0.2.7+1
+version: 0.2.7+2
 author: Dart Team <misc@dartlang.org>
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static
 environment:
-  sdk: '>=2.0.0-dev.17.0 <2.0.0'
+  sdk: '>=2.0.0-dev.55.0 <2.0.0'
 dependencies:
   convert: '>=1.0.0 <3.0.0'
   http_parser: '>=0.0.2+2 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 0.2.7+2
+version: 0.2.7+1
 author: Dart Team <misc@dartlang.org>
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static


### PR DESCRIPTION
Please land and publish.

Fixes #29.