### PR TITLE
Use the text/css MIME type for "*.css" data files.

### DIFF
--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -16,7 +16,8 @@ import 'directory_listing.dart';
 import 'util.dart';
 
 /// The default resolver for MIME types based on file extensions.
-final _defaultMimeTypeResolver = new MimeTypeResolver();
+final _defaultMimeTypeResolver = new MimeTypeResolver()
+  ..addExtension('css', 'text/css');
 
 // TODO option to exclude hidden files?
 


### PR DESCRIPTION
This fixes Bolt errors like:

    Refused to apply style from 'http://localhost:8080/some/path/file.css' because its MIME type ('text/plain') is not a supported stylesheet MIME type, and strict MIME checking is enabled.
