### PR TITLE
Use file modified date for 304 checks ("changed" is creation date on Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.9
+
+* Use file `modified` dates instead of `changed` for `304 Not Modified` checks
+  as `changed` returns creation dates on Windows.
+
 ## 0.2.8
 
 * Update SDK constraint to `>=2.0.0-dev.61 <3.0.0`.

--- a/lib/src/static_handler.dart
+++ b/lib/src/static_handler.dart
@@ -182,7 +182,7 @@ Future<Response> _handleFile(
   var ifModifiedSince = request.ifModifiedSince;
 
   if (ifModifiedSince != null) {
-    var fileChangeAtSecResolution = toSecondResolution(stat.changed);
+    var fileChangeAtSecResolution = toSecondResolution(stat.modified);
     if (!fileChangeAtSecResolution.isAfter(ifModifiedSince)) {
       return new Response.notModified();
     }
@@ -190,7 +190,7 @@ Future<Response> _handleFile(
 
   var headers = {
     HttpHeaders.contentLengthHeader: stat.size.toString(),
-    HttpHeaders.lastModifiedHeader: formatHttpDate(stat.changed)
+    HttpHeaders.lastModifiedHeader: formatHttpDate(stat.modified)
   };
 
   var contentType = await getContentType();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 0.2.8
+version: 0.2.9
 author: Dart Team <misc@dartlang.org>
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static

--- a/test/basic_file_test.dart
+++ b/test/basic_file_test.dart
@@ -86,7 +86,7 @@ void main() {
     var handler = createStaticHandler(d.sandbox);
 
     var rootPath = p.join(d.sandbox, 'root.txt');
-    var modified = new File(rootPath).statSync().changed.toUtc();
+    var modified = new File(rootPath).statSync().modified.toUtc();
 
     var response = await makeRequest(handler, '/root.txt');
     expect(response.lastModified, atSameTimeToSecond(modified));
@@ -97,7 +97,7 @@ void main() {
       var handler = createStaticHandler(d.sandbox);
 
       var rootPath = p.join(d.sandbox, 'root.txt');
-      var modified = new File(rootPath).statSync().changed.toUtc();
+      var modified = new File(rootPath).statSync().modified.toUtc();
 
       var headers = {
         HttpHeaders.ifModifiedSinceHeader: formatHttpDate(modified)
@@ -112,7 +112,7 @@ void main() {
       var handler = createStaticHandler(d.sandbox);
 
       var rootPath = p.join(d.sandbox, 'root.txt');
-      var modified = new File(rootPath).statSync().changed.toUtc();
+      var modified = new File(rootPath).statSync().modified.toUtc();
 
       var headers = {
         HttpHeaders.ifModifiedSinceHeader:
@@ -128,7 +128,7 @@ void main() {
       var handler = createStaticHandler(d.sandbox);
 
       var rootPath = p.join(d.sandbox, 'root.txt');
-      var modified = new File(rootPath).statSync().changed.toUtc();
+      var modified = new File(rootPath).statSync().modified.toUtc();
 
       var headers = {
         HttpHeaders.ifModifiedSinceHeader:

--- a/test/sample_test.dart
+++ b/test/sample_test.dart
@@ -62,7 +62,7 @@ Future _testFileContents(String filename) async {
 
   var response = await _requestFile(filename);
   expect(response.contentLength, fileStat.size);
-  expect(response.lastModified, atSameTimeToSecond(fileStat.changed.toUtc()));
+  expect(response.lastModified, atSameTimeToSecond(fileStat.modified.toUtc()));
   await _expectCompletesWithBytes(response, fileContents);
 }
 


### PR DESCRIPTION
This fixes #37 for me on Windows, however I don't know if there are any other consequences of changing this. The field named `changed` states in its dartdoc that on Windows is returns the creation date. Based on [this SO answer](https://unix.stackexchange.com/a/2803/84496) it seems like on other platforms it returns the time of the last metadata change (whereas `modified` is file contents change).

If there's a reason to use `changed` for non-Windows platforms this could be made conditional (or perhaps just the latest of the two dates used?) - let me know if I should do that.

I added a test that catches this on Windows (it fails without the change, passes with), though the bots here don't run on Windows so currently wouldn't catch a regression. It also requires a small delay (2s) to ensure the timestamp changed - though if you're happy to check only the status code, it might be possible to drop that.