### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/test/basic_file_test.dart
+++ b/test/basic_file_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/sample_test.dart
+++ b/test/sample_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.