### PR TITLE
Allow the null safe convert and http_parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.9-dev
 
 * Update SDK constraint to `>=2.3.0 <3.0.0`.
+* Allow `3.x` versions of `package:convert`.
 * Use file `modified` dates instead of `changed` for `304 Not Modified` checks
   as `changed` returns creation dates on Windows.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 0.2.9-dev
+version: 0.2.9
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static
 
@@ -7,8 +7,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  convert: '>=1.0.0 <3.0.0'
-  http_parser: '>=0.0.2+2 <4.0.0'
+  convert: '>=1.0.0 <4.0.0'
+  http_parser: '>=0.0.2+2 <5.0.0'
   mime: '>=0.9.0 <0.10.0'
   path: '>=1.1.0 <2.0.0'
   shelf: '>=0.5.7 <0.8.0'


### PR DESCRIPTION
Expand the upper bounds of the constraints to allow the breaking change
for the null safety migration. Tested locally with overrides to force
picking up the latest prerelease versions.