### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.2.9-dev
+## 0.2.9
 
 * Update SDK constraint to `>=2.3.0 <3.0.0`.
 * Allow `3.x` versions of `package:convert`.
+* Allow `4.x` versions of `package:http_parser`.
 * Use file `modified` dates instead of `changed` for `304 Not Modified` checks
   as `changed` returns creation dates on Windows.
 
@@ -51,7 +52,7 @@
 
 ## 0.2.3
 
-* Added `listDirectories` argument to `createStaticHandler`. 
+* Added `listDirectories` argument to `createStaticHandler`.
 
 ## 0.2.2
 
@@ -61,7 +62,7 @@
 
 ## 0.2.1
 
-* Removed `Uri` format checks now that the core libraries is more strict. 
+* Removed `Uri` format checks now that the core libraries is more strict.
 
 ## 0.2.0
 


### PR DESCRIPTION
- Drop -dev suffix from changelog version
- Add not about changed constraint on `http_parser` for consistency.