### PR TITLE
Bump `mime` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9+1
+
+* Change version constraint for the `mime` dependency, so it accepts null-safe versions.
+
 ## 0.2.9
 
 * Update SDK constraint to `>=2.3.0 <3.0.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 0.2.9
+version: 0.2.9+1
 description: Static file server support for Shelf
 homepage: https://github.com/dart-lang/shelf_static
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   convert: '>=1.0.0 <4.0.0'
   http_parser: '>=0.0.2+2 <5.0.0'
-  mime: '>=0.9.0 <0.10.0'
+  mime: '>=0.9.0 <=1.0.0'
   path: '>=1.1.0 <2.0.0'
   shelf: '>=0.5.7 <0.8.0'
 


### PR DESCRIPTION
Fixes:
```
Because shelf_static >=0.2.8 depends on mime ^0.9.0 and shelf_static >=0.1.0+1 <0.2.8 requires SDK version >=1.0.0 <2.0.0 or >=2.0.0-dev.55.0 <2.0.0, shelf_static >=0.1.0+1 requires mime ^0.9.0.
And because test >=1.16.0-nullsafety.7 depends on shelf_static ^0.2.6, test >=1.16.0-nullsafety.7 requires mime ^0.9.0.
So, because share depends on both mime ^1.0.0-nullsafety.0 and test ^1.16.0-nullsafety.13, version solving failed.
```