### PR TITLE
Send 405 (Method Not Allowed) – for requests that are not `HEAD`/`GET`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 1.1.0-dev
+## 1.1.0
 
+* Correctly send 405 (Method Not Allowed) – for requests that are not `HEAD` or
+  `GET` method.
 * Correctly handle `HEAD` requests.
 
 ## 1.0.0

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -2,7 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:shelf/shelf.dart';
+
 DateTime toSecondResolution(DateTime dt) {
   if (dt.millisecond == 0) return dt;
   return dt.subtract(Duration(milliseconds: dt.millisecond));
 }
+
+Response notFound() => Response.notFound('Not Found');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_static
-version: 1.1.0-dev
+version: 1.1.0
 description: Static file server support for the shelf package and ecosystem
 repository: https://github.com/dart-lang/shelf_static
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -35,7 +35,7 @@ Handler _rootHandler(String? path, Handler handler) {
 
   return (Request request) {
     if (!_ctx.isWithin('/$path', request.requestedUri.path)) {
-      return Response.notFound('not found');
+      return notFound();
     }
     assert(request.handlerPath == '/');
 


### PR DESCRIPTION
Fixes dart-lang/shelf#227

Also prepare to release v1.1.0
